### PR TITLE
update urls in docs after github org move

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,6 +1,6 @@
 Beagle uses the Apache 2.0 license.
 
-The source is hosted on github https://github.com/dhellmann/beagle
+The source is hosted on github https://github.com/beaglecli/beagle
 
 Please fork the repository and propose pull requests with clean
 patches.

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,6 @@ Beagle is a command line client for Hound_, the code search tool.
 
 .. _Hound: https://github.com/etsy/hound
 
-The source code is available from https://github.com/dhellmann/beagle.
+The source code is available from https://github.com/beaglecli/beagle.
 
 The documentation is available from http://beagle-hound.readthedocs.io/en/latest/

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -11,8 +11,8 @@ Beagle is a command line client for Hound_, the code search tool.
 
 .. _Hound: https://github.com/etsy/hound
 
-:Source: https://github.com/dhellmann/beagle
-:Bugs: https://github.com/dhellmann/beagle/issues
+:Source: https://github.com/beaglecli/beagle
+:Bugs: https://github.com/beaglecli/beagle/issues
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
The beagle repo moved from dhellmann/beagle to beaglecli/beagle, so
update references to the old location.