### PR TITLE
Redirect project's home page

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ description-file =
     README.rst
 author = Doug Hellmann
 author-email = doug@doughellmann.com
-home-page = https://github.com/dhellmann/beagle
+home-page = https://github.com/beaglecli/beagle/
 classifier =
     Intended Audience :: Developers
     Intended Audience :: Information Technology


### PR DESCRIPTION
Redirect project's home page to match the recent move to the dedicated organization.