### PR TITLE
Add install_requires on setuptools in setup.cfg for pkg_resources

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,8 @@ author = Doug Hellmann
 author-email = doug@doughellmann.com
 home-page = https://github.com/beaglecli/beagle/
 python-requires = >=3.6
+install_requires =
+   setuptools
 classifier =
     Intended Audience :: Developers
     Intended Audience :: Information Technology


### PR DESCRIPTION
This is useful for downstream distribution packagers to determine
runtime dependency of setuptools vs build time dependency