### PR TITLE
Add install_requires on setuptools in setup.cfg for pkg_resources

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,8 @@ classifier =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+install_requires =
+   setuptools
 
 [files]
 packages =


### PR DESCRIPTION
This is useful for downstream distribution packagers to determine runtime dependency of setuptools vs build time dependency

This is a "clone" of #14, because the branch is stale and the fork is apparently non longer available