### PR TITLE
Add --exclude option to implement file exclusion

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,8 @@ jobs:
       run: tox -e pep8
     - name: Check covering
       run: tox -e cover
+    - name: Run unit tests
+      run: tox -e unit
     - name: Test with tox
       run: tox
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ doc/build
 .coverage
 build/
 .venv/
-*/__pycache__/
+*__pycache__/

--- a/beagle/search.py
+++ b/beagle/search.py
@@ -56,6 +56,13 @@ class Search(lister.Lister):
             help='file name pattern',
         )
         parser.add_argument(
+            '--exclude',
+            dest='exclude',
+            action='append',
+            default=[],
+            help='exclude files or paths matching glob pattern (repeatable)',
+        )
+        parser.add_argument(
             '--ignore-case',
             default=False,
             action='store_true',
@@ -96,6 +103,12 @@ class Search(lister.Lister):
 
         for repo, repo_matches in sorted(interesting_repos):
             for repo_match in repo_matches['Matches']:
+                filename = repo_match['Filename']
+                # Exclude files matching any exclude pattern
+                if parsed_args.exclude:
+                    if any(fnmatch.fnmatch(filename, pat)
+                       for pat in parsed_args.exclude):
+                        continue
                 for file_match in repo_match['Matches']:
                     if (parsed_args.ignore_comments and
                         file_match['Line'].lstrip().startswith(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,63 @@
+import unittest
+
+
+class DummyArgs:
+    def __init__(self, exclude=None, repo_pattern=None,
+                 ignore_comments=False, comment_marker='#', context_lines=0):
+        self.exclude = exclude or []
+        self.repo_pattern = repo_pattern or ''
+        self.ignore_comments = ignore_comments
+        self.comment_marker = comment_marker
+        self.context_lines = context_lines
+
+
+class TestBeagleSearchExclude(unittest.TestCase):
+    def setUp(self):
+        # Simulate results as returned by hound.query
+        self.results = {
+            'repo1': {
+                'Matches': [
+                    {'Filename': 'src/main.py',
+                     'Matches': [{'LineNumber': 1,
+                                  'Line': 'foo', 'Before': [], 'After': []}]},
+                    {'Filename': 'src/test_utils.py',
+                     'Matches': [{'LineNumber': 2,
+                                  'Line': 'bar', 'Before': [], 'After': []}]},
+                    {'Filename': 'docs/readme.py',
+                     'Matches': [{'LineNumber': 3, 'Line': 'baz',
+                                  'Before': [], 'After': []}]},
+                ]
+            }
+        }
+
+    def test_exclude_pattern(self):
+        from beagle.search import Search
+        search = Search(app=None, app_args=None)
+        args = DummyArgs(exclude=['*test*', '*doc*'])
+        found = list(search._flatten_results(self.results, args))
+        # Only src/main.py should remain
+        self.assertEqual(len(found), 1)
+        self.assertIn('src/main.py', found[0])
+
+    def test_no_exclude(self):
+        from beagle.search import Search
+        search = Search(app=None, app_args=None)
+        args = DummyArgs(exclude=[])
+        found = list(search._flatten_results(self.results, args))
+        self.assertEqual(len(found), 3)
+        self.assertIn('src/main.py', found[0])
+        self.assertIn('src/test_utils.py', found[1])
+        self.assertIn('docs/readme.py', found[2])
+
+    def test_partial_exclude(self):
+        from beagle.search import Search
+        search = Search(app=None, app_args=None)
+        args = DummyArgs(exclude=['*test*'])
+        found = list(search._flatten_results(self.results, args))
+        self.assertEqual(len(found), 2)
+        self.assertIn('src/main.py', found[0])
+        self.assertIn('docs/readme.py', found[1])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.2.0
-envlist = py39,py310,py311,py312,py313,pep8
+envlist = py39,py310,py311,py312,py313,pep8,unit
 
 [testenv]
 usedevelop = True
@@ -29,6 +29,14 @@ commands =
 deps = -r{toxinidir}/doc/requirements.txt
 commands =
     sphinx-build -a -E -W -b html doc/source doc/build/html
+
+[testenv:unit]
+description = Run pytest-based unit tests
+deps =
+    pytest
+    -rrequirements.txt
+commands =
+    pytest tests
 
 [flake8]
 # E123, E125 skipped as they are invalid PEP-8.


### PR DESCRIPTION
- Add --exclude (repeatable) option to beagle search for glob-based file/path exclusion.
- Apply exclusion logic in search results, skipping files matching any exclude pattern.
- Create and standardize tests using pytest style.
- Add edge case and pattern coverage to tests.
- Update .gitignore for standard Python/dev artifacts.
- Add [testenv:unit] to tox.ini for pytest-based tests and include in envlist.
- Update CI to run tox -e unit for unit tests.