### PR TITLE
move requirements to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,10 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13"
 ]
-dependencies = []
+dependencies = [
+    "cliff>=2.11.0",
+    "requests>=2.18.4"
+]
 dynamic = ["version"]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-pbr>=2.0
-cliff>=2.11.0
-requests>=2.18.4


### PR DESCRIPTION
I forgot to migrate the requirements so we now have an error when we run beagle after the installation because cliff is missing. This patch will fix that error.